### PR TITLE
Added new link for Book cover image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Learning OpenCV 4 Computer Vision with Python 3 - Third Edition 
 
-<a href="https://www.packtpub.com/data/learning-opencv-4-computer-vision-with-python-3-third-edition?utm_source=github&utm_medium=repository&utm_campaign=9781789531619"><img src="https://www.packtpub.com/media/catalog/product/cache/ecd051e9670bd57df35c8f0b122d8aea/9/7/9781789531619-original.jpeg" alt="Learning OpenCV 4 Computer Vision with Python 3 - Third Edition " height="256px" align="right"></a>
+<a href="https://www.packtpub.com/data/learning-opencv-4-computer-vision-with-python-3-third-edition?utm_source=github&utm_medium=repository&utm_campaign=9781789531619"><img src="https://static.packt-cdn.com/products/9781789531619/cover/smaller" alt="Learning OpenCV 4 Computer Vision with Python 3 - Third Edition " height="256px" align="right"></a>
 
 This is the code repository for [Learning OpenCV 4 Computer Vision with Python 3 - Third Edition ](https://www.packtpub.com/data/learning-opencv-4-computer-vision-with-python-3-third-edition?utm_source=github&utm_medium=repository&utm_campaign=9781789531619), published by Packt.
 


### PR DESCRIPTION
Old link for the book cover image was throwing 404, so updated the link.