### PR TITLE
Python hangs on exit from Cameo without CaptureManager.release()

### DIFF
--- a/chapter02/cameo/cameo.py
+++ b/chapter02/cameo/cameo.py
@@ -23,6 +23,8 @@ class Cameo(object):
             self._captureManager.exitFrame()
             self._windowManager.processEvents()
 
+        self._captureManager.release()
+
     def onKeypress(self, keycode):
         """Handle a keypress.
 

--- a/chapter02/cameo/managers.py
+++ b/chapter02/cameo/managers.py
@@ -138,6 +138,10 @@ class CaptureManager(object):
 
         self._videoWriter.write(self._frame)
 
+    def release(self):
+        self._capture.release()
+        self._capture = None
+
 
 class WindowManager(object):
 


### PR DESCRIPTION
Cameo needs to `.release()` the cv2.VideoCapture stream before exiting.  This PR implements that functionality.