### PR TITLE
Replace missing variable in homography example

### DIFF
--- a/chapter06/homography.py
+++ b/chapter06/homography.py
@@ -66,4 +66,4 @@ if len(good_matches) >= MIN_NUM_GOOD_MATCHES:
     plt.show()
 else:
     print("Not enough matches good were found - %d/%d" % \
-          (len(good_matches), MIN_MATCH_COUNT))
+          (len(good_matches), MIN_NUM_GOOD_MATCHES))


### PR DESCRIPTION
In chapter06/homography.py there is a missing variable MIN_MATCH_COUNT that probably should be replaced with MIN_NUM_GOOD_MATCHES.